### PR TITLE
Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Official implementation of DistSeal, a unified framework for latent watermarking
 [ [Colab](https://colab.research.google.com/github/facebookresearch/distseal/blob/main/notebooks/colab.ipynb) ]
 [ [Paper](https://scontent-sjc3-1.xx.fbcdn.net/v/t39.2365-6/603028033_905511885552755_4967480041688018421_n.pdf?_nc_cat=110&ccb=1-7&_nc_sid=3c67a6&_nc_ohc=J19JF6eIvJwQ7kNvwGOlV-n&_nc_oc=AdkofKPvU4h-p-wqZYs65ShxPFF29k7MXqy57K2n2_2hu1moVwrOeypVGF3qS-8DDIY4z4NzWznVWs3rGsJwG9ic&_nc_zt=14&_nc_ht=scontent-sjc3-1.xx&_nc_gid=yFl4l1JLtHBm5d8lB2Q-5w&oh=00_AfkB4IWAKQj2TCSBBOb8xQdHH3Dzgr8Wx7ajlYn68poP_g&oe=694AAF2D) ]
 [ [Blog](https://ai.meta.com/research/publications/distilling-latent-space-watermarkers-into-generative-image-models/) ]
-
+[ [Meta Seal](https://facebookresearch.github.io/meta-seal/) ]
 </div>
 <p align="center">
     <img src="assets/distseal.png" alt="Latent Watermarking" width="100%"/>
@@ -318,7 +318,7 @@ which provides a rich set of image attacks and robustness metrics. The robustnes
 Ensure to choose the detector card which match the generated images (see the model cards table above).
 
 ```
-pip install "git+https://github.com/facebookresearch/omnisealbench.git[image]"`
+pip install "git+https://github.com/facebookresearch/omnisealbench.git#egg=omnisealbench[image]"
 
 # For RAR-XL, resolution = 256, for DC-AE, resolution = 512
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ print(f"Average bit accuracy: {bit_acc * 100:.2f}%")
 ```
 
 # 🚀 Usage: post-hoc latent watermarking
-We also provide notebooks for RAR (`notebooks/posthoc_rar.ipynb`) and DCAE (`notebooks/posthoc_dcae.ipynb`) illustrating post-hoc latent watermarking on an example image. The latent encoder first encodes the loaded image into latents which are watermarked by the post-hoc latent watermarker. We visualize the watermarked image by decoding the watermarked latents back to the pixel space, and then detect the watermark from the final image.
+We also provide notebooks for RAR ([`notebooks/posthoc_rar.ipynb`](./notebooks/posthoc_rar.ipynb)) and DCAE ([`notebooks/posthoc_dcae.ipynb`](./notebooks/posthoc_dcae.ipynb)) illustrating post-hoc latent watermarking on an example image. The latent encoder first encodes the loaded image into latents which are watermarked by the post-hoc latent watermarker. We visualize the watermarked image by decoding the watermarked latents back to the pixel space, and then detect the watermark from the final image.
 
 
 
@@ -359,7 +359,7 @@ If you find this work useful, please consider giving the repo a star ⭐ :) and 
 
 # 📃 License
 
-The model is licensed under an [MIT license](LICENSE).
+The model and code are licensed under [MIT license](LICENSE).
 
 # Contributing
 


### PR DESCRIPTION
We add the links to Meta Seal, as well as fix the link to the (newly updated) Omniseal Bench repo